### PR TITLE
nearest neighborhoods search

### DIFF
--- a/src/main/java/present/Location.java
+++ b/src/main/java/present/Location.java
@@ -7,39 +7,63 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class Location {
 
-  private final double latitude;
-  private final double longitude;
+    /**
+     * Earth radius in kilometers
+     */
+    public static final double R = 6372;
 
-  /**
-   * Constructs a new set of coordinates
-   *
-   * @param latitude in degrees
-   * @param longitude in degrees
-   */
-  public Location(double latitude, double longitude) {
-    this.latitude = latitude;
-    this.longitude = longitude;
-  }
+    private final double latitude;
+    private final double longitude;
 
-  /** Returns the latitude in degrees. */
-  public double latitude() {
-    return latitude;
-  }
+    /**
+     * Constructs a new set of coordinates
+     *
+     * @param latitude  in degrees
+     * @param longitude in degrees
+     */
+    public Location(double latitude, double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
 
-  /** Returns the latitude in degrees. */
-  public double longitude() {
-    return longitude;
-  }
+    /**
+     * Returns the latitude in degrees.
+     */
+    public double latitude() {
+        return latitude;
+    }
 
-  /**
-   * Computes the great-circle distance (https://en.wikipedia.org/wiki/Great-circle_distance)
-   * between this location and another in km.
-   */
-  public double distanceTo(Location other) {
-    distanceComputations.incrementAndGet();
+    /**
+     * Returns the latitude in degrees.
+     */
+    public double longitude() {
+        return longitude;
+    }
 
-    throw new UnsupportedOperationException("Please implement!");
-  }
+    /**
+     * Computes the great-circle distance (https://en.wikipedia.org/wiki/Great-circle_distance)
+     * between this location and another in km.
+     */
+    public double distanceTo(Location other) {
+        distanceComputations.incrementAndGet();
+        return calculateDistance(Math.toRadians(latitude()), Math.toRadians(longitude()),
+                Math.toRadians(other.latitude()), Math.toRadians(other.longitude()));
+    }
 
-  static AtomicInteger distanceComputations = new AtomicInteger();
+    /**
+     * Calculates the distance between two points using the Haversine formula.
+     *
+     * @param latitude1  The latitude of point 1 in radians.
+     * @param longitude1 The longitude of point 1 in radians.
+     * @param latitude2  The latitude of point 2 in radians.
+     * @param longitude2 The longitude of point 2 in radians.
+     * @return The distance between two points in kilometers.
+     */
+    private double calculateDistance(double latitude1, double longitude1, double latitude2, double longitude2) {
+        double a = Math.pow(Math.sin((latitude2 - latitude1) / 2), 2)
+                + Math.cos(latitude1) * Math.cos(latitude2) * Math.pow(Math.sin((longitude2 - longitude1) / 2), 2);
+        return R * 2 * Math.asin(Math.min(1, Math.sqrt(a)));
+    }
+
+    static AtomicInteger distanceComputations = new AtomicInteger();
 }

--- a/src/main/java/present/Search.java
+++ b/src/main/java/present/Search.java
@@ -1,20 +1,88 @@
 package present;
 
-import java.util.List;
+import java.util.*;
 
 /**
  * Searches {@link Neighborhoods#ALL}.
  */
 public class Search {
 
-  /**
-   * Finds the {@code n} neighborhoods nearest to the given location.
-   *
-   * @param location to search near
-   * @param n number of neighborhoods to return
-   * @return the {@code n} nearest neighborhoods, ordered nearest to farthest
-   */
-  public static List<Neighborhood> near(Location location, int n) {
-    throw new UnsupportedOperationException("Please implement!");
-  }
+    /**
+     * Finds the {@code n} neighborhoods nearest to the given location.
+     *
+     * @param location to search near
+     * @param n        number of neighborhoods to return
+     * @return the {@code n} nearest neighborhoods, ordered nearest to farthest
+     */
+    public static List<Neighborhood> near(Location location, int n) {
+        Map<Neighborhood, Double> distanceCache = new HashMap<>();
+        final int neighborhoodsSize = Neighborhoods.ALL.size();
+        final double[] dist = new double[neighborhoodsSize];
+        int i = 0;
+        for (Neighborhood neighborhood : Neighborhoods.ALL) {
+            dist[i] = neighborhood.location().distanceTo(location);
+            distanceCache.put(neighborhood, dist[i]);
+            i++;
+        }
+        final double nthMinDistance = nthSmallestDistance(dist, 0, neighborhoodsSize - 1, n);
+
+        TreeMap<Double, Neighborhood> result = new TreeMap<>();
+        int j = 0;
+        for (Map.Entry<Neighborhood, Double> neighborhood : distanceCache.entrySet()) {
+            if (j >= n) {
+                break;
+            }
+            if (neighborhood.getValue() <= nthMinDistance) {
+                result.put(neighborhood.getValue(), neighborhood.getKey());
+                j++;
+            }
+        }
+
+        return new LinkedList<>(result.values());
+    }
+
+    private static double nthSmallestDistance(double[] distances, int left, int right, int n) {
+        //System.out.println(left + " "+ right);
+        if (left == right) {
+            return distances[left];
+        }
+        if (left < right) {
+            final int pivot = randomizedPartition(distances, left, right);
+            final int pivotIndex = pivot - left + 1;
+            if (n == pivotIndex) {
+                return distances[pivot];
+            } else if (n < pivotIndex) {
+                return nthSmallestDistance(distances, left, pivot - 1, n);
+            } else {
+                return nthSmallestDistance(distances, pivot + 1, right, n - pivotIndex);
+            }
+        } else {
+            return Double.MIN_VALUE;
+        }
+    }
+
+    private static void swap(double[] array, int index1, int index2) {
+        final double temp = array[index1];
+        array[index1] = array[index2];
+        array[index2] = temp;
+    }
+
+    private static int partition(double[] array, int left, int right) {
+        final double pivot = array[right];
+        int i = left;
+        for (int j = left; j < right; j++) {
+            if (array[j] <= pivot) {
+                swap(array, i, j);
+                i++;
+            }
+        }
+        swap(array, i, right);
+        return i;
+    }
+
+    private static int randomizedPartition(double[] array, int left, int right) {
+        final int pivot = (int) Math.round(left + Math.random() * (right - left));
+        swap(array, pivot, right);
+        return partition(array, left, right);
+    }
 }


### PR DESCRIPTION
My solution to find n closest neighborhoods consist of steps:

1. First calculating all Neighborhood -> Location distances and adding it to a map. Time complexity of this step is O(n) where n is number of neighborhoods.
2. Find nth smallest distance using quickselect. Time complexity of this step is O(n) where n is number of neighborhoods.
3. Iterate over neighborhood -> distance values and add values with distance smaller or equal to nth smallest distance to result TreeMap. Time complexity of this step is O(n*logk) where n is number of neighborhoods and k is number of closest neighborhoods to be returned. Using TreeMap ensures that returned Neighborhoods list is sorted by distance. This could be skipped if actual result set order wouldn’t matter. 

Caching calculated distances saved n distance calculations (where n is number of neighborhoods). In given example exact number of computations saved with my implementation was 287.

Overall time complexity is  O(nlogk). To beat O(n) it would require some pre-processing of Neighborhoods, i.e. putting all neighborhoods to k-d tree and then searching for n nearest neighborhoods in this tree.
To scale this solution, we could compute n nearest neighborhoods in parallel on different neighborhoods sets and then merge sorted results returning n with smallest distance.