### PR TITLE
Demo solution

### DIFF
--- a/src/main/java/present/Location.java
+++ b/src/main/java/present/Location.java
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class Location {
 
+  private static final int EARTH_RADIUS_KM = 6372;
   private final double latitude;
   private final double longitude;
 
@@ -38,7 +39,15 @@ public class Location {
   public double distanceTo(Location other) {
     distanceComputations.incrementAndGet();
 
-    throw new UnsupportedOperationException("Please implement!");
+    double latitude1 = Math.toRadians(latitude);
+    double longitude1 = Math.toRadians(longitude);
+    double latitude2 = Math.toRadians(other.latitude);
+    double longitude2 = Math.toRadians(other.longitude);
+
+    double angleInRadians = Math.acos(
+            Math.sin(latitude1) * Math.sin(latitude2)
+                    + Math.cos(latitude1) * Math.cos(latitude2) * Math.cos(longitude1 - longitude2));
+    return EARTH_RADIUS_KM * angleInRadians;
   }
 
   static AtomicInteger distanceComputations = new AtomicInteger();

--- a/src/main/java/present/NeighborhoodDistance.java
+++ b/src/main/java/present/NeighborhoodDistance.java
@@ -1,0 +1,23 @@
+package present;
+
+/**
+ * Just a wrapper to keep a neighborhood packaged with the distance from a location so they can be sorted.
+ */
+public class NeighborhoodDistance {
+
+  public NeighborhoodDistance(double distance, Neighborhood neighborhood) {
+    this.distance = distance;
+    this.neighborhood = neighborhood;
+  }
+
+  private double distance;
+  private Neighborhood neighborhood;
+
+  public Neighborhood neighborhood() {
+    return neighborhood;
+  }
+
+  public double distance() {
+    return distance;
+  }
+}

--- a/src/main/java/present/Search.java
+++ b/src/main/java/present/Search.java
@@ -1,6 +1,8 @@
 package present;
 
-import java.util.List;
+import com.google.common.collect.Lists;
+
+import java.util.*;
 
 /**
  * Searches {@link Neighborhoods#ALL}.
@@ -15,6 +17,85 @@ public class Search {
    * @return the {@code n} nearest neighborhoods, ordered nearest to farthest
    */
   public static List<Neighborhood> near(Location location, int n) {
-    throw new UnsupportedOperationException("Please implement!");
+
+    // Head is biggest distance in queue
+    PriorityQueue<NeighborhoodDistance> priorityQueue = new PriorityQueue<>((o1, o2) -> Double.compare(o2.distance(), o1.distance()));
+
+    for (Neighborhood neighborhood : Neighborhoods.ALL) {
+      addToQueueIfNearby(location, n, priorityQueue, neighborhood);
+    }
+
+    return toNeighborhoodListSortedByDistance(priorityQueue);
+  }
+
+  private static List<Neighborhood> toNeighborhoodListSortedByDistance(PriorityQueue<NeighborhoodDistance> priorityQueue) {
+    List<NeighborhoodDistance> nearestNeighborhoodDistances = Lists.newArrayList(priorityQueue);
+    nearestNeighborhoodDistances.sort(Comparator.comparingDouble(NeighborhoodDistance::distance));
+    return Lists.transform(nearestNeighborhoodDistances, NeighborhoodDistance::neighborhood);
+  }
+
+  /**
+   * Add a neighborhood to the queue if it's not full yet, or if it's closer than the current worst neighborhood.
+   * If the queue is full, evict the previous furthest neighborhood when we add a new one.
+   */
+  private static void addToQueueIfNearby(Location location, int n, PriorityQueue<NeighborhoodDistance> priorityQueue, Neighborhood neighborhood) {
+    double distance = location.distanceTo(neighborhood.location());
+    if (priorityQueue.size() < n) {
+      priorityQueue.add(new NeighborhoodDistance(distance, neighborhood));
+    } else if (priorityQueue.peek().distance() > distance) {
+      priorityQueue.remove(); // peek() and remove() are both O(1)
+      priorityQueue.add(new NeighborhoodDistance(distance, neighborhood));
+    }
+  }
+
+  public static List<Neighborhood> nearSorted(Location location, int n) {
+    PriorityQueue<NeighborhoodDistance> priorityQueue = new PriorityQueue<>((o1, o2) -> Double.compare(o2.distance(), o1.distance()));
+
+    // Multiplying by -1 assumes the binary search returns a target index and never a real match
+    int closestLatitudeIndex = -Collections.binarySearch(SortedNeighborhoods.LOCATIONS_BY_LATITUDE, location, Comparator.comparingDouble(Location::latitude));
+    int closestLongitudeIndex = -Collections.binarySearch(SortedNeighborhoods.LOCATIONS_BY_LONGITUDE, location, Comparator.comparingDouble(Location::longitude));
+
+    // TODO: Do in a loop, increasing the search radius number
+    int searchRadiusNumber = 5 * n;
+    List<Neighborhood> sublist = getAdjacentSublist(SortedNeighborhoods.BY_LATITUDE, closestLatitudeIndex, searchRadiusNumber);
+    HashSet<Neighborhood> closestNeighborhoodsByLatitude = new HashSet<Neighborhood>(sublist); // O(n)
+
+    getAdjacentSublist(SortedNeighborhoods.BY_LONGITUDE, closestLongitudeIndex, searchRadiusNumber).forEach(neighborhood -> {
+      if (closestNeighborhoodsByLatitude.contains(neighborhood)) {
+        addToQueueIfNearby(location, n, priorityQueue, neighborhood);
+      } else {
+        // add to a list to reconsider on the next pass with an expanded search radius
+      }
+    });
+
+    return toNeighborhoodListSortedByDistance(priorityQueue);
+  }
+
+  /**
+   * Get a sublist of the input list by taking n on either side of the target index. If not possible, take 2n including
+   * the target index and beginning or end of the list (whichever is a bound).  If list's size is smaller than
+   * 2n just return the list.
+   *
+   * @param input
+   * @param targetIndex
+   * @param n
+   * @param <T>
+   * @return
+   */
+  private static <T> List<T> getAdjacentSublist(List<T> input, int targetIndex, int n) {
+    if (input.size() < 2 * n) return input;
+    int upperBound;
+    int lowerBound;
+    if (targetIndex + n > input.size()) {
+      upperBound = input.size();
+      lowerBound = input.size() - n;
+    } else if (targetIndex - n < 0) {
+      lowerBound = 0;
+      upperBound = 2 * n;
+    } else {
+      upperBound = targetIndex + n;
+      lowerBound = targetIndex - n;
+    }
+    return input.subList(lowerBound, upperBound);
   }
 }

--- a/src/main/java/present/SortedNeighborhoods.java
+++ b/src/main/java/present/SortedNeighborhoods.java
@@ -1,0 +1,26 @@
+package present;
+
+import com.google.common.collect.Lists;
+
+import java.util.*;
+
+public class SortedNeighborhoods {
+
+    private SortedNeighborhoods() {}
+
+    public static final List<Neighborhood> BY_LATITUDE = new ArrayList<Neighborhood>(Neighborhoods.ALL);
+    public static final List<Neighborhood> BY_LONGITUDE = new ArrayList<Neighborhood>(Neighborhoods.ALL);
+    public static final List<Location> LOCATIONS_BY_LATITUDE;
+    public static final List<Location> LOCATIONS_BY_LONGITUDE;
+
+
+    static {
+        BY_LATITUDE.sort(Comparator.comparingDouble(o -> o.location().latitude()));
+        BY_LONGITUDE.sort(Comparator.comparingDouble(o -> o.location().longitude()));
+
+        // Collections.binarySearch() wanted a List<Location); maybe there's a way to work around but let's just
+        // make these here while we're pre-processing
+        LOCATIONS_BY_LATITUDE = Lists.transform(SortedNeighborhoods.BY_LATITUDE, o -> o.location());
+        LOCATIONS_BY_LONGITUDE = Lists.transform(SortedNeighborhoods.BY_LONGITUDE, o -> o.location());
+    }
+}

--- a/src/test/java/present/SearchTest.java
+++ b/src/test/java/present/SearchTest.java
@@ -48,6 +48,43 @@ public class SearchTest {
     assertEquals(expected, Lists.transform(actual, Neighborhood::name));
   }
 
+  @Test public void nearPresentSorted() {
+    List<String> expected = ImmutableList.of(
+            "Union Square",
+            "Chinatown",
+            "Financial District",
+            "Nob Hill",
+            "Tenderloin"
+    );
+    List<Neighborhood> actual = Search.nearSorted(new Location(37.7904251, -122.4059803), 5);
+    assertEquals(expected, Lists.transform(actual, Neighborhood::name));
+  }
+
+  @Test public void nearThePaintedLadiesSorted() {
+    List<String> expected = ImmutableList.of(
+            "Haight-Ashbury",
+            "North of Panhandle",
+            "Anza Vista"
+    );
+    List<Neighborhood> actual = Search.nearSorted(new Location(37.7722899,-122.4421448), 3);
+    assertEquals(expected, Lists.transform(actual, Neighborhood::name));
+  }
+
+  @Test public void nearLegionOfHonorSorted() {
+    List<String> expected = ImmutableList.of(
+            "Seacliff",
+            "Sunset District",
+            "Richmond District",
+            "Inner Sunset",
+            "San Francisco",
+            "Presidio Terrace",
+            "Jordan Park",
+            "Forest Hill"
+    );
+    List<Neighborhood> actual = Search.nearSorted(new Location(37.7747202, -122.5101659), 8);
+    assertEquals(expected, Lists.transform(actual, Neighborhood::name));
+  }
+
   @Before public void resetCounter() {
     Location.distanceComputations.set(0);
   }


### PR DESCRIPTION
Hi!  First of all, thanks for this problem. It was the most interesting of all the demo projects I’ve done and even gave me something to talk about over drinks with my husband, who invented his own algorithm in O(nk) on the spot. :) 

One note -- this is my first time writing Java 8, just in case I did something funny (I come from Android land). I used IntelliJ and it’s just as nice on its own as in Android Studio.

## First pass: O(n)
My first pass uses a PriorityQueue to hold the current nearest neighborhoods as it calculates the distance for each existing neighborhood. At the end, I sort the nearest neighborhoods. This has a complexity of O(nlog(k) + klog(k)) where *k* is the number of nearest neighborhoods, so O(n)!  A different way would be to put the whole list of neighborhoods in the priority queue and pop it *k* times, no need to sort. (O(n + klogn).

The bummer with both these methods is O(n) isn’t just the worst case but the expected case too: 301 distance calculations every time.

## Pre-sorted example: O(logn)
If we’re allowed to sort the neighborhoods beforehand, things get better.  I wrote a VERY rough example of a method you could use to search neighborhoods in chunks from a starting location.  I wouldn’t use this in prod, but its major benefits are that you can design it on a cocktail napkin and it’s a good proof of concept :)

Say we have one list of neighborhoods sorted by longitude and another by latitude.  Finding the closest latitude neighbor is O(log(n)), and same for longitude.  This gives us a much better place to start a search because the longitude or latitude of our furthest neighborhood vary from our current position by, at most, the total distance.  
I demonstrate taking *r* of the closest neighborhoods on either side of the target index by both latitude and longitude and taking the intersection of the sublists.  That runs in O(r). Then we perform the search as above which is O(r).  I don’t do any checking or looping in my method -- I just pick R as a linear function of *k*, the number of nearest neighborhoods -- but one would know not to continue the search any more when the lat or long deltas of the points you examine are larger than the distance in the head of the priority queue (furthest “near” distance).  On a large data set where *r* is small, even if we have to increase *r* and repeat several times, this falls back to O(logn).  In my example, it took 8, 17, and 18 calculations instead of 301.

One note: among my MANY other shortcuts here, this approach (sorted lists) works for the discrete part of the world represented in the sample but in real life, -179 degrees of longitude would be close to +1 degree

## Best real life approach:
The best real-life approach would probably be calculating a graph for all neighborhoods of the closest X other neighborhoods to them and their distances. I’d have to read up on the best way to store and search that structure, but it seems like this would be the best and most efficient data structure since what we really care about is distance, not the individual lat and lon.

## Other ideas: 
- Cache! we should absolutely be caching both distance calculations for a pair of locations, and the nearby neighborhoods for a location, in something like very very big LruCaches. 
- Round? If we decrease the accuracy of our lookups (round our input numbers), we can increase the rate of cache hits.


